### PR TITLE
feat: add ALB+Cognito authentication and security enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 data
 .env
 .DS_Store
+iac/kb-*.txt

--- a/agent/client.py
+++ b/agent/client.py
@@ -2,6 +2,7 @@ import boto3
 import json
 import argparse
 import uuid
+import base64
 
 parser = argparse.ArgumentParser(description="Create an agent runtime")
 parser.add_argument("--agent_runtime_arn", required=True, help="Agent runtime arn")
@@ -17,9 +18,12 @@ account = sts_client.get_caller_identity()["Account"]
 
 agent_core_client = boto3.client("bedrock-agentcore")
 
+# Encode user_id with base64 for AgentCore compatibility
+user_id = base64.b64encode("test-user".encode()).decode().rstrip('=')
+
 payload = json.dumps({
     "input": {
-        "user_id": "6886c5c5ced611f1af8885b941a07a61",
+        "user_id": user_id,
         "prompt": "Who are you and what can you do?"
     }
 })
@@ -30,6 +34,7 @@ print(f"invoking agent with session id: {session_id}")
 response = agent_core_client.invoke_agent_runtime(
     agentRuntimeArn=agent_runtime_arn,
     runtimeSessionId=session_id,
+    runtimeUserId=user_id,
     payload=payload,
 )
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,6 +5,11 @@ set -e
 export APP=$1
 export ARCH=$2
 
+# Validate required variables
+[ -z "$APP" ] && { echo "Error: APP variable is empty"; exit 1; }
+[ -z "$ARCH" ] && { echo "Error: ARCH variable is empty"; exit 1; }
+[ -z "$AWS_REGION" ] && { echo "Error: AWS_REGION variable is empty"; exit 1; }
+
 export VERSION=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w 50 | head -n 1)
 
 # login to ECR

--- a/iac/cognito.tf
+++ b/iac/cognito.tf
@@ -1,0 +1,64 @@
+resource "aws_cognito_user_pool" "main" {
+  count = var.enable_authentication ? 1 : 0
+  name = var.name
+
+  auto_verified_attributes = ["email"]
+  admin_create_user_config {
+    allow_admin_create_user_only = true
+  }
+  
+  password_policy {
+    minimum_length    = 8
+    require_lowercase = true
+    require_numbers   = true
+    require_symbols   = true
+    require_uppercase = true
+  }
+
+  schema {
+    attribute_data_type = "String"
+    name               = "email"
+    required           = true
+    mutable            = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cognito_user_pool_client" "main" {
+  count        = var.enable_authentication ? 1 : 0
+  name         = var.name
+  user_pool_id = aws_cognito_user_pool.main[0].id
+
+  generate_secret                      = true
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes                 = ["email", "openid", "profile"]
+  
+  callback_urls = var.acm_certificate_arn != "" ? [
+    "https://${module.alb.dns_name}/oauth2/idpresponse"
+  ] : [
+    "http://${module.alb.dns_name}/oauth2/idpresponse"
+  ]
+
+  logout_urls = var.acm_certificate_arn != "" ? [
+    "https://${module.alb.dns_name}"
+  ] : [
+    "http://${module.alb.dns_name}"
+  ]
+
+  supported_identity_providers = ["COGNITO"]
+}
+
+resource "aws_cognito_user_pool_domain" "main" {
+  count        = var.enable_authentication ? 1 : 0
+  domain       = "${var.name}-${random_string.cognito_domain[0].result}"
+  user_pool_id = aws_cognito_user_pool.main[0].id
+}
+
+resource "random_string" "cognito_domain" {
+  count   = var.enable_authentication ? 1 : 0
+  length  = 8
+  special = false
+  upper   = false
+}

--- a/iac/create-user.sh
+++ b/iac/create-user.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Script to create a Cognito user for the AI Agent application
+
+set -e
+
+# Get Cognito User Pool ID from Terraform output
+USER_POOL_ID=$(terraform output -raw cognito_user_pool_id)
+
+if [ -z "$USER_POOL_ID" ]; then
+    echo "Error: Could not get Cognito User Pool ID from Terraform output"
+    exit 1
+fi
+
+# Prompt for user email
+read -p "Enter email address for the new user: " EMAIL
+
+if [ -z "$EMAIL" ]; then
+    echo "Error: Email address is required"
+    exit 1
+fi
+
+# Prompt for temporary password
+read -s -p "Enter temporary password (min 8 chars, must include uppercase, lowercase, number, symbol): " TEMP_PASSWORD
+echo
+
+if [ -z "$TEMP_PASSWORD" ]; then
+    echo "Error: Password is required"
+    exit 1
+fi
+
+echo "Creating user in Cognito User Pool: $USER_POOL_ID"
+
+# Create the user
+aws cognito-idp admin-create-user \
+    --user-pool-id "$USER_POOL_ID" \
+    --username "$EMAIL" \
+    --user-attributes Name=email,Value="$EMAIL" Name=email_verified,Value=true \
+    --temporary-password "$TEMP_PASSWORD" \
+    --message-action SUPPRESS
+
+echo "User created successfully!"
+echo "Email: $EMAIL"
+echo "Temporary password: $TEMP_PASSWORD"
+echo ""
+echo "The user will need to change their password on first login."
+echo "Access the application at: $(terraform output -raw endpoint)"

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -52,3 +52,23 @@ output "s3_bucket_name" {
   description = "The name of the s3 bucket that was created"
   value       = aws_s3_bucket.main.bucket
 }
+
+output "cognito_user_pool_id" {
+  description = "Cognito User Pool ID"
+  value       = var.enable_authentication ? aws_cognito_user_pool.main[0].id : null
+}
+
+output "cognito_user_pool_client_id" {
+  description = "Cognito User Pool Client ID"
+  value       = var.enable_authentication ? aws_cognito_user_pool_client.main[0].id : null
+}
+
+output "cognito_domain" {
+  description = "Cognito Domain for authentication"
+  value       = var.enable_authentication ? "https://${aws_cognito_user_pool_domain.main[0].domain}.auth.${data.aws_region.current.name}.amazoncognito.com" : null
+}
+
+output "alb_logs_bucket_name" {
+  description = "The name of the S3 bucket for ALB access logs"
+  value       = aws_s3_bucket.alb_logs.bucket
+}

--- a/iac/s3.tf
+++ b/iac/s3.tf
@@ -17,3 +17,59 @@ resource "aws_s3_bucket" "llm_logs" {
   bucket        = "${var.name}-llm-logs-${local.account_id}"
   force_destroy = true
 }
+
+# bucket for storing ALB access logs
+resource "aws_s3_bucket" "alb_logs" {
+  bucket        = "${var.name}-alb-logs-${local.account_id}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_elb_service_account" "main" {}
+
+resource "aws_s3_bucket_policy" "alb_logs" {
+  bucket = aws_s3_bucket.alb_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_elb_service_account.main.arn
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.alb_logs.arn}/*"
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.alb_logs.arn}/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.alb_logs.arn
+      }
+    ]
+  })
+}

--- a/iac/terraform.tfvars.example
+++ b/iac/terraform.tfvars.example
@@ -1,0 +1,31 @@
+name = "agent"
+tags = {
+  app = "agent"
+}
+
+# Restrict web interface access to specific IP addresses
+# Replace with your actual IP addresses/CIDR blocks
+allowed_ips = [
+  "203.0.113.0/24",    # Example office network
+  "198.51.100.5/32",   # Example specific IP
+  "192.0.2.0/24"       # Example home network
+]
+
+# These will be populated after agent deployment
+# agentcore_runtime_arn = "arn:aws:bedrock-agentcore:<region>:<account-id>:runtime/<agent-suffix>"
+# agentcore_memory_id = "agent-suffix"
+
+# Optional: ACM certificate ARN for HTTPS support
+acm_certificate_arn = "arn:aws:acm:<region>:<account-id>:certificate/<certificate-id>"
+
+# Enable ALB+Cognito authentication (default: false)
+# Uncomment to enable authentication for production deployments
+# enable_authentication = true
+
+# Custom Cognito logout URL (for custom domains)
+# If not specified, will use default: https://<domain>.auth.<region>.amazoncognito.com/logout?client_id=<client_id>&logout_uri=
+# cognito_logout_url = "https://auth.yourdomain.com/logout?client_id=your-client-id&logout_uri="
+
+# ALB Logging Configuration
+alb_access_logs_enabled = true
+alb_connection_logs_enabled = true

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -50,3 +50,44 @@ variable "agentcore_memory_id" {
   type        = string
   default     = ""
 }
+
+variable "allowed_ips" {
+  description = "List of IP addresses/CIDR blocks allowed to access the web interface"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of the ACM certificate for HTTPS listener"
+  type        = string
+  default     = ""
+}
+
+variable "alb_access_logs_enabled" {
+  description = "Enable ALB access logs"
+  type        = bool
+  default     = false
+}
+
+variable "alb_connection_logs_enabled" {
+  description = "Enable ALB connection logs"
+  type        = bool
+  default     = false
+}
+
+variable "enable_authentication" {
+  description = "Enable ALB+Cognito authentication"
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = !var.enable_authentication || var.acm_certificate_arn != ""
+    error_message = "SSL/TLS certificate (acm_certificate_arn) is required when authentication is enabled. ALB authentication requires HTTPS for security."
+  }
+}
+
+variable "cognito_logout_url" {
+  description = "Custom Cognito logout URL (overrides default constructed URL)"
+  type        = string
+  default     = null
+}

--- a/static/style.css
+++ b/static/style.css
@@ -64,6 +64,38 @@ body {
 	transition: transform 0.2s ease;
 }
 
+/* User Info Styles */
+.user-info {
+	align-items: center;
+	gap: 1rem;
+}
+
+.user-email {
+	color: rgba(255, 255, 255, 0.9);
+	font-size: 0.9rem;
+	font-weight: 500;
+	background: rgba(255, 255, 255, 0.1);
+	padding: 0.5rem 1rem;
+	border-radius: 20px;
+	backdrop-filter: blur(10px);
+	border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.user-info .btn-outline-light {
+	border-color: rgba(255, 255, 255, 0.3);
+	color: white;
+	background: rgba(255, 255, 255, 0.1);
+	backdrop-filter: blur(10px);
+	transition: all 0.3s ease;
+}
+
+.user-info .btn-outline-light:hover {
+	background: rgba(255, 255, 255, 0.2);
+	border-color: rgba(255, 255, 255, 0.5);
+	color: white;
+	transform: translateY(-1px);
+}
+
 /* Main Container */
 .main-container {
 	background: var(--dark-bg);

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,10 +79,18 @@
     <!-- Header -->
     <header class="app-header">
       <div class="container">
-        <div class="row">
+        <div class="row align-items-center">
           <div class="col">
             <a href="/" class="app-title"> ✨ AI Agent Accelerator</a>
           </div>
+          {% if auth_enabled and user_email %}
+          <div class="col-auto">
+            <div class="user-info d-flex align-items-center">
+              <span class="user-email me-3">👤 {{ user_email }}</span>
+              <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+            </div>
+          </div>
+          {% endif %}
         </div>
       </div>
     </header>


### PR DESCRIPTION
- Add optional ALB+Cognito authentication with enable_authentication flag
- Implement IP-based access restrictions via allowed_ips parameter
- Add SSL/TLS support with ACM certificate integration
- Create Cognito user pool and user pool client for authentication
- Add create-user.sh script for easy user management
- Update ECS task definition with authentication environment variables
- Enhance documentation with security configuration examples
- Add terraform.tfvars.example template for easy setup
- Update UI styling and templates for authentication flow
- Add S3 bucket policy and ALB access logging configuration

## TODO
- [ ] Updated architecture documentation (diagram)
- [ ] Update UI screenshot with example of logged-in screen.

## Testing
- [x] Tested with authentication disabled (default behavior)
- [x] Tested with authentication enabled
- [x] Verified IP restrictions work correctly
- [x] Confirmed SSL/TLS integration

## Key Features Added
- **Optional ALB+Cognito Authentication**: Controlled via \`enable_authentication\` flag
- **IP-based Access Control**: Restrict access via \`allowed_ips\` parameter  
- **SSL/TLS Support**: Integration with ACM certificates for HTTPS
- **User Management**: Convenient \`create-user.sh\` script for Cognito user creation
- **Enhanced Security**: Proper authentication flow with session management


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
